### PR TITLE
Bugfix for original alignment

### DIFF
--- a/filters/page_layout/Params.cpp
+++ b/filters/page_layout/Params.cpp
@@ -22,8 +22,8 @@
 
 namespace page_layout {
     Params::Params(const Margins& hard_margins_mm,
-                   const QRectF& content_rect,
                    const QRectF& page_rect,
+                   const QRectF& content_rect,
                    const QSizeF& content_size_mm,
                    const Alignment& alignment,
                    const bool auto_margins)


### PR DESCRIPTION
I guess there is a misplace of two arguments that was unnoticed as both has same type. The order in header (https://github.com/4lex4/scantailor-advanced/blob/master/filters/page_layout/Params.h#L36) is the correct one. As far as I can tell this ruins Original alignment results. Although Petr Kovář still didn't reply me on this.