### PR TITLE
Fix build with Qt 5.11

### DIFF
--- a/DefaultParamsDialog.h
+++ b/DefaultParamsDialog.h
@@ -2,13 +2,16 @@
 #ifndef SCANTAILOR_DEFAULTPARAMSDIALOG_H
 #define SCANTAILOR_DEFAULTPARAMSDIALOG_H
 
-#include <QtWidgets/QWidget>
-#include <unordered_map>
-#include <set>
 #include "ui_DefaultParamsDialog.h"
 #include "OrthogonalRotation.h"
 #include "DefaultParamsProfileManager.h"
 #include "DefaultParams.h"
+
+#include <QButtonGroup>
+#include <QWidget>
+
+#include <unordered_map>
+#include <set>
 
 class DefaultParamsDialog : public QDialog, private Ui::DefaultParamsDialog {
     Q_OBJECT

--- a/ErrorWidget.cpp
+++ b/ErrorWidget.cpp
@@ -18,6 +18,9 @@
 
 #include "ErrorWidget.h"
 
+#include <QIcon>
+#include <QStyle>
+
 ErrorWidget::ErrorWidget(const QString& text, Qt::TextFormat fmt) {
     setupUi(this);
     textLabel->setTextFormat(fmt);

--- a/filters/deskew/ApplyDialog.h
+++ b/filters/deskew/ApplyDialog.h
@@ -22,7 +22,10 @@
 #include "PageId.h"
 #include "PageSequence.h"
 #include "intrusive_ptr.h"
+
+#include <QButtonGroup>
 #include <QDialog>
+
 #include <set>
 
 class QButtonGroup;

--- a/filters/fix_orientation/ApplyDialog.h
+++ b/filters/fix_orientation/ApplyDialog.h
@@ -24,7 +24,10 @@
 #include "PageRange.h"
 #include "PageSequence.h"
 #include "intrusive_ptr.h"
+
+#include <QButtonGroup>
 #include <QDialog>
+
 #include <vector>
 #include <set>
 

--- a/filters/output/ApplyColorsDialog.h
+++ b/filters/output/ApplyColorsDialog.h
@@ -23,7 +23,10 @@
 #include "PageId.h"
 #include "PageSequence.h"
 #include "intrusive_ptr.h"
+
+#include <QButtonGroup>
 #include <QDialog>
+
 #include <set>
 
 class PageSelectionAccessor;

--- a/filters/output/ChangeDewarpingDialog.h
+++ b/filters/output/ChangeDewarpingDialog.h
@@ -24,8 +24,11 @@
 #include "PageId.h"
 #include "PageSequence.h"
 #include "intrusive_ptr.h"
+
+#include <QButtonGroup>
 #include <QDialog>
 #include <QString>
+
 #include <set>
 
 class PageSelectionAccessor;

--- a/filters/output/ChangeDpiDialog.h
+++ b/filters/output/ChangeDpiDialog.h
@@ -23,8 +23,11 @@
 #include "PageId.h"
 #include "PageSequence.h"
 #include "intrusive_ptr.h"
+
+#include <QButtonGroup>
 #include <QDialog>
 #include <QString>
+
 #include <set>
 
 class PageSelectionAccessor;

--- a/filters/page_layout/ApplyDialog.h
+++ b/filters/page_layout/ApplyDialog.h
@@ -24,7 +24,10 @@
 #include "PageRange.h"
 #include "PageSequence.h"
 #include "intrusive_ptr.h"
+
+#include <QButtonGroup>
 #include <QDialog>
+
 #include <set>
 
 class PageSelectionAccessor;

--- a/filters/page_split/SplitModeDialog.h
+++ b/filters/page_split/SplitModeDialog.h
@@ -25,7 +25,10 @@
 #include "PageId.h"
 #include "PageSequence.h"
 #include "intrusive_ptr.h"
+
+#include <QButtonGroup>
 #include <QDialog>
+
 #include <set>
 
 class ProjectPages;

--- a/filters/select_content/ApplyDialog.h
+++ b/filters/select_content/ApplyDialog.h
@@ -24,7 +24,10 @@
 #include "PageRange.h"
 #include "PageSequence.h"
 #include "intrusive_ptr.h"
+
+#include <QButtonGroup>
 #include <QDialog>
+
 #include <vector>
 #include <set>
 


### PR DESCRIPTION
Upgrade to Qt 5.11 causes failing packages everywhere because of internal header cleanup, this commit is fixing scantailor-advanced.