### PR TITLE
Generate and upload AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: xenial
+
+before_install:
+  - sudo add-apt-repository ppa:beineri/opt-qt595-xenial -y
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get -y install qt59base qt59translations qt59tools mesa-common-dev libjpeg-dev zlib1g-dev libpng-dev libtiff-dev libboost-all-dev libxrender-dev
+  - source /opt/qt*/bin/qt*-env.sh
+
+script:
+  - sed -i -e 's|Boost 1.60|Boost 1.50|g' CMakeLists.txt
+  - cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+  - make -j$(nproc)
+  - make DESTDIR=appdir -j$(nproc) install ; find appdir/
+  - mkdir -p ./appdir/usr/share/metainfo/ ; cp ./resources/unix/scantailor.appdata.xml ./appdir/usr/share/metainfo/
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
+
+after_success:
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh Scan*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/resources/unix/scantailor.appdata.xml
+++ b/resources/unix/scantailor.appdata.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.github.scantailor-advanced</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>ScanTailor Advanced</name>
+  <summary>An interactive post-processing tool for scanned pages.</summary>
+  <description>
+    <p>
+      ScanTailor Advanced is an interactive post-processing tool for scanned pages.
+      It performs operations such as page splitting, deskewing, adding/removing borders, and others.
+      You give it raw scans, and you get pages ready to be printed or assembled into a PDF or DJVU file.
+      Scanning, optical character recognition, and assembling multi-page documents are out of scope of this project.
+    </p>
+    <p>
+      ScanTailor Advanced is Free Software (which is more than just freeware).
+      It’s written in C++ with Qt and released under the General Public License version 3.
+    </p>
+    <p>
+      ScanTailor Advanced is being used not just by enthusiasts, but also by libraries and other institutions.
+    </p>
+  </description>
+  <launchable type="desktop-id">scantailor.desktop</launchable>
+  <url type="bugtracker">https://github.com/4lex4/scantailor-advanced/issues</url>
+  <url type="homepage">https://github.com/4lex4/scantailor-advanced</url>
+  <content_rating type="oars-1.1" />
+</component>


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.

cc @zdenop @marathone