### PR TITLE
Make speckles more visible and add despeckle overlay if no speckles are detected

### DIFF
--- a/src/core/filters/output/DespeckleVisualization.cpp
+++ b/src/core/filters/output/DespeckleVisualization.cpp
@@ -41,7 +41,7 @@ void DespeckleVisualization::colorizeSpeckles(QImage& image, const imageproc::Bi
   const uint32_t* sedmLine = sedm.data();
   const int sedmStride = sedm.stride();
 
-  const float radius = static_cast<float>(30.0 * std::max(dpi.horizontal(), dpi.vertical()) / 600);
+  const float radius = static_cast<float>(45.0 * std::max(dpi.horizontal(), dpi.vertical()) / 600);
   const float sqRadius = radius * radius;
 
   for (int y = 0; y < h; ++y) {
@@ -56,7 +56,7 @@ void DespeckleVisualization::colorizeSpeckles(QImage& image, const imageproc::Bi
         continue;
       }
 
-      const float alphaUpperBound = 0.6f;
+      const float alphaUpperBound = 0.7f;
       const float scale = alphaUpperBound / sqRadius;
       const float alpha = alphaUpperBound - scale * sqDist;
       if (alpha > 0) {

--- a/src/core/filters/output/DespeckleVisualization.cpp
+++ b/src/core/filters/output/DespeckleVisualization.cpp
@@ -27,29 +27,6 @@ DespeckleVisualization::DespeckleVisualization(const QImage& output,
   if (!speckles.isNull()) {
     colorizeSpeckles(m_image, speckles, dpi);
   }
-  else {
-    const int w = m_image.width();
-    const int h = m_image.height();
-    auto* imageLine = (uint32_t*) m_image.bits();
-    const int imageStride = m_image.bytesPerLine() / 4;
-    const float overlayAlpha = 0.4;
-    
-    if (overlayAlpha > 0) {
-      const float imageAlpha = 1.0f - overlayAlpha;
-      const float overlayR = 255;
-      const float overlayG = 0;
-      const float overlayB = 0;
-      for (int y = 0; y < h; ++y) {
-        for (int x = 0; x < w; ++x) {
-          const float r = overlayR * overlayAlpha + qRed(imageLine[x]) * imageAlpha;
-          const float g = overlayG * overlayAlpha + qGreen(imageLine[x]) * imageAlpha;
-          const float b = overlayB * overlayAlpha + qBlue(imageLine[x]) * imageAlpha;
-          imageLine[x] = qRgb(int(r), int(g), int(b));
-        }
-        imageLine += imageStride;
-      }
-    }
-  }
 
   m_downscaledImage = ImageViewBase::createDownscaledImage(m_image);
 }
@@ -66,7 +43,7 @@ void DespeckleVisualization::colorizeSpeckles(QImage& image, const imageproc::Bi
 
   const float radius = static_cast<float>(45.0 * std::max(dpi.horizontal(), dpi.vertical()) / 600);
   const float sqRadius = radius * radius;
-
+  
   for (int y = 0; y < h; ++y) {
     for (int x = 0; x < w; ++x) {
       const uint32_t sqDist = sedmLine[x];
@@ -80,8 +57,11 @@ void DespeckleVisualization::colorizeSpeckles(QImage& image, const imageproc::Bi
       }
 
       const float alphaUpperBound = 0.7f;
+      const float noSpecklesOverlayAlpha = 0.3f;
       const float scale = alphaUpperBound / sqRadius;
-      const float alpha = alphaUpperBound - scale * sqDist;
+      const float alpha = (sqDist == INF_DIST // check if there are any speckles
+                           ? noSpecklesOverlayAlpha
+                           : alphaUpperBound - scale * sqDist);
       if (alpha > 0) {
         const float alpha2 = 1.0f - alpha;
         const float overlayR = 255;

--- a/src/core/filters/output/DespeckleVisualization.cpp
+++ b/src/core/filters/output/DespeckleVisualization.cpp
@@ -27,6 +27,29 @@ DespeckleVisualization::DespeckleVisualization(const QImage& output,
   if (!speckles.isNull()) {
     colorizeSpeckles(m_image, speckles, dpi);
   }
+  else {
+    const int w = m_image.width();
+    const int h = m_image.height();
+    auto* imageLine = (uint32_t*) m_image.bits();
+    const int imageStride = m_image.bytesPerLine() / 4;
+    const float overlayAlpha = 0.4;
+    
+    if (overlayAlpha > 0) {
+      const float imageAlpha = 1.0f - overlayAlpha;
+      const float overlayR = 255;
+      const float overlayG = 0;
+      const float overlayB = 0;
+      for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+          const float r = overlayR * overlayAlpha + qRed(imageLine[x]) * imageAlpha;
+          const float g = overlayG * overlayAlpha + qGreen(imageLine[x]) * imageAlpha;
+          const float b = overlayB * overlayAlpha + qBlue(imageLine[x]) * imageAlpha;
+          imageLine[x] = qRgb(int(r), int(g), int(b));
+        }
+        imageLine += imageStride;
+      }
+    }
+  }
 
   m_downscaledImage = ImageViewBase::createDownscaledImage(m_image);
 }

--- a/src/core/filters/output/DespeckleVisualization.cpp
+++ b/src/core/filters/output/DespeckleVisualization.cpp
@@ -43,7 +43,7 @@ void DespeckleVisualization::colorizeSpeckles(QImage& image, const imageproc::Bi
 
   const float radius = static_cast<float>(45.0 * std::max(dpi.horizontal(), dpi.vertical()) / 600);
   const float sqRadius = radius * radius;
-  
+
   for (int y = 0; y < h; ++y) {
     for (int x = 0; x < w; ++x) {
       const uint32_t sqDist = sedmLine[x];

--- a/src/core/filters/output/DespeckleVisualization.cpp
+++ b/src/core/filters/output/DespeckleVisualization.cpp
@@ -59,7 +59,7 @@ void DespeckleVisualization::colorizeSpeckles(QImage& image, const imageproc::Bi
       const float alphaUpperBound = 0.7f;
       const float noSpecklesOverlayAlpha = 0.3f;
       const float scale = alphaUpperBound / sqRadius;
-      const float alpha = (sqDist == INF_DIST // check if there are any speckles
+      const float alpha = (sqDist == SEDM::INF_DIST // check if there are any speckles
                            ? noSpecklesOverlayAlpha
                            : alphaUpperBound - scale * sqDist);
       if (alpha > 0) {

--- a/src/core/filters/output/DespeckleVisualization.cpp
+++ b/src/core/filters/output/DespeckleVisualization.cpp
@@ -41,7 +41,7 @@ void DespeckleVisualization::colorizeSpeckles(QImage& image, const imageproc::Bi
   const uint32_t* sedmLine = sedm.data();
   const int sedmStride = sedm.stride();
 
-  const float radius = static_cast<float>(15.0 * std::max(dpi.horizontal(), dpi.vertical()) / 600);
+  const float radius = static_cast<float>(30.0 * std::max(dpi.horizontal(), dpi.vertical()) / 600);
   const float sqRadius = radius * radius;
 
   for (int y = 0; y < h; ++y) {
@@ -56,7 +56,7 @@ void DespeckleVisualization::colorizeSpeckles(QImage& image, const imageproc::Bi
         continue;
       }
 
-      const float alphaUpperBound = 0.8f;
+      const float alphaUpperBound = 0.6f;
       const float scale = alphaUpperBound / sqRadius;
       const float alpha = alphaUpperBound - scale * sqDist;
       if (alpha > 0) {

--- a/src/core/filters/page_layout/OptionsWidget.ui
+++ b/src/core/filters/page_layout/OptionsWidget.ui
@@ -200,8 +200,8 @@ QToolButton:pressed {
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="rightMarginSpinBox">
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="topMarginSpinBox">
             <property name="decimals">
              <number>1</number>
             </property>
@@ -220,8 +220,8 @@ QToolButton:pressed {
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="topMarginSpinBox">
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="leftMarginSpinBox">
             <property name="decimals">
              <number>1</number>
             </property>
@@ -237,8 +237,8 @@ QToolButton:pressed {
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="leftMarginSpinBox">
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="rightMarginSpinBox">
             <property name="decimals">
              <number>1</number>
             </property>


### PR DESCRIPTION
I use despeckling for every book I process using Scantailor, and manual review of speckles always took me most of the time I spent on a book digitalisation, since you need to check each page whether there are no "false positives" that would clear proper contents of the book (like dots etc).

So I made this little tweak which changes two things in Output → Despeckling tab:
1. It makes red circular areas highlighting speckles bigger, and thus more visible;
2. In case there are no detected speckles (and Despeckling is turned on), it will overlay the whole picture with semitransparent red cover, so you immediately know that there are no speckles that you need to check.