### PR TITLE
Add missing QPainterPath includes

### DIFF
--- a/src/app/ThumbnailSequence.cpp
+++ b/src/app/ThumbnailSequence.cpp
@@ -11,6 +11,7 @@
 #include <QGraphicsScene>
 #include <QGraphicsSceneMouseEvent>
 #include <QGraphicsView>
+#include <QPainterPath>
 #include <QStyleOptionGraphicsItem>
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QMessageBox>

--- a/src/core/IncompleteThumbnail.cpp
+++ b/src/core/IncompleteThumbnail.cpp
@@ -5,6 +5,7 @@
 
 #include <QDebug>
 #include <QPainter>
+#include <QPainterPath>
 #include <utility>
 
 QPainterPath IncompleteThumbnail::m_sCachedPath;

--- a/src/core/ThumbnailBase.cpp
+++ b/src/core/ThumbnailBase.cpp
@@ -7,6 +7,7 @@
 
 #include <QApplication>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPixmapCache>
 #include <QStyleOptionGraphicsItem>
 #include <cmath>

--- a/src/core/filters/page_layout/Thumbnail.cpp
+++ b/src/core/filters/page_layout/Thumbnail.cpp
@@ -6,6 +6,7 @@
 #include <PolygonUtils.h>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <utility>
 
 #include "Utils.h"


### PR DESCRIPTION
Some files were still missing an

    #include <QPainterPath>

3d1e74e6ace413733511086934a66f4e3f7a6027 fixed some of the compile errors, but I found other places where `QPainterPath` is used and added it there.

