### PR TITLE
Issue #164 - Fix TIFF saving when JPEG and posterized

### DIFF
--- a/src/core/TiffWriter.cpp
+++ b/src/core/TiffWriter.cpp
@@ -222,8 +222,10 @@ bool TiffWriter::writeBitonalOrIndexed8Image(const TiffHandle& tif, const QImage
   }
 
   if (image.format() == QImage::Format_Indexed8) {
-    TIFFSetField(tif.handle(), TIFFTAG_COMPRESSION,
-                 uint16(ApplicationSettings::getInstance().getTiffColorCompression()));
+    uint16 compress = (photometric == PHOTOMETRIC_PALETTE) ?
+                      COMPRESSION_LZW :
+                      uint16(ApplicationSettings::getInstance().getTiffColorCompression());
+    TIFFSetField(tif.handle(), TIFFTAG_COMPRESSION, compress);
   } else {
     TIFFSetField(tif.handle(), TIFFTAG_COMPRESSION, uint16(ApplicationSettings::getInstance().getTiffBwCompression()));
   }


### PR DESCRIPTION
In case of indexed colours, it will compress in LZW, otherwise libtiff fails.