### PR TITLE
Fix OpenGL rendering on Wayland

### DIFF
--- a/src/core/ImageViewBase.cpp
+++ b/src/core/ImageViewBase.cpp
@@ -150,16 +150,16 @@ ImageViewBase::ImageViewBase(const QImage& image,
 
   if (ApplicationSettings::getInstance().isOpenGlEnabled()) {
     if (OpenGLSupport::supported()) {
-//       QGLFormat format;
-//       format.setSampleBuffers(true);
-//       format.setStencil(true);
-//       format.setAlpha(true);
-//       format.setRgba(true);
-//       format.setDepth(false);
-
+      //QGLFormat format;
+      //format.setSampleBuffers(true);
+      //format.setStencil(true);
+      //format.setAlpha(true);
+      //format.setRgba(true);
+      //format.setDepth(false);
+      
       // Most of hardware refuses to work for us with direct rendering enabled.
-//       format.setDirectRendering(false);
-
+      //format.setDirectRendering(false);
+        
       setViewport(new QOpenGLWidget());
     }
   }

--- a/src/core/ImageViewBase.cpp
+++ b/src/core/ImageViewBase.cpp
@@ -7,7 +7,8 @@
 #include <Transform.h>
 
 #include <QApplication>
-#include <QGLWidget>
+// #include <QGLWidget>
+#include <QOpenGLWidget>
 #include <QMouseEvent>
 #include <QPaintEngine>
 #include <QPainter>
@@ -149,17 +150,17 @@ ImageViewBase::ImageViewBase(const QImage& image,
 
   if (ApplicationSettings::getInstance().isOpenGlEnabled()) {
     if (OpenGLSupport::supported()) {
-      QGLFormat format;
-      format.setSampleBuffers(true);
-      format.setStencil(true);
-      format.setAlpha(true);
-      format.setRgba(true);
-      format.setDepth(false);
+//       QGLFormat format;
+//       format.setSampleBuffers(true);
+//       format.setStencil(true);
+//       format.setAlpha(true);
+//       format.setRgba(true);
+//       format.setDepth(false);
 
       // Most of hardware refuses to work for us with direct rendering enabled.
-      format.setDirectRendering(false);
+//       format.setDirectRendering(false);
 
-      setViewport(new QGLWidget(format));
+      setViewport(new QOpenGLWidget());
     }
   }
 


### PR DESCRIPTION
Move away from the deprecated QGLWidget involving problematic native windows/surfaces (see https://doc.qt.io/qt-5/qopenglwidget.html#relation-to-qglwidget). Use the newer QOpenGLWidget instead.

I do not know any C++ and only built this fix using hints from other programs facing similar problems. Although it seems to work, the code is probably incomplete.