### PR TITLE
feature #198: binarizeEdgePlus

### DIFF
--- a/src/app/DefaultParamsDialog.cpp
+++ b/src/app/DefaultParamsDialog.cpp
@@ -47,6 +47,7 @@ DefaultParamsDialog::DefaultParamsDialog(QWidget* parent)
   thresholdMethodBox->addItem(tr("Otsu"), OTSU);
   thresholdMethodBox->addItem(tr("Sauvola"), SAUVOLA);
   thresholdMethodBox->addItem(tr("Wolf"), WOLF);
+  thresholdMethodBox->addItem(tr("EdgePlus"), EDGEPLUS);
 
   pictureShapeSelector->addItem(tr("Off"), OFF_SHAPE);
   pictureShapeSelector->addItem(tr("Free"), FREE_SHAPE);
@@ -660,7 +661,7 @@ std::unique_ptr<DefaultParams> DefaultParamsDialog::buildParams() const {
   blackWhiteOptions.setBinarizationMethod(binarizationMethod);
   blackWhiteOptions.setThresholdAdjustment(thresholdSlider->value());
   blackWhiteOptions.setSauvolaCoef(sauvolaCoef->value());
-  if (binarizationMethod == SAUVOLA) {
+  if (binarizationMethod == SAUVOLA || binarizationMethod == EDGEPLUS) {
     blackWhiteOptions.setWindowSize(sauvolaWindowSize->value());
   } else if (binarizationMethod == WOLF) {
     blackWhiteOptions.setWindowSize(wolfWindowSize->value());

--- a/src/core/filters/output/BlackWhiteOptions.cpp
+++ b/src/core/filters/output/BlackWhiteOptions.cpp
@@ -72,6 +72,8 @@ BinarizationMethod BlackWhiteOptions::parseBinarizationMethod(const QString& str
     return WOLF;
   } else if (str == "sauvola") {
     return SAUVOLA;
+  } else if (str == "edgeplus") {
+    return EDGEPLUS;
   } else {
     return OTSU;
   }
@@ -88,6 +90,9 @@ QString BlackWhiteOptions::formatBinarizationMethod(BinarizationMethod type) {
       break;
     case WOLF:
       str = "wolf";
+      break;
+    case EDGEPLUS:
+      str = "edgeplus";
       break;
   }
   return str;

--- a/src/core/filters/output/BlackWhiteOptions.h
+++ b/src/core/filters/output/BlackWhiteOptions.h
@@ -9,7 +9,7 @@ class QDomDocument;
 class QDomElement;
 
 namespace output {
-enum BinarizationMethod { OTSU, SAUVOLA, WOLF };
+enum BinarizationMethod { OTSU, SAUVOLA, WOLF, EDGEPLUS };
 
 class BlackWhiteOptions {
  public:

--- a/src/core/filters/output/OptionsWidget.cpp
+++ b/src/core/filters/output/OptionsWidget.cpp
@@ -42,14 +42,19 @@ OptionsWidget::OptionsWidget(std::shared_ptr<Settings> settings, const PageSelec
   thresholdMethodBox->addItem(tr("Otsu"), OTSU);
   thresholdMethodBox->addItem(tr("Sauvola"), SAUVOLA);
   thresholdMethodBox->addItem(tr("Wolf"), WOLF);
+  thresholdMethodBox->addItem(tr("EdgePlus"), EDGEPLUS);
 
   fillingColorBox->addItem(tr("Background"), FILL_BACKGROUND);
   fillingColorBox->addItem(tr("White"), FILL_WHITE);
 
-  QPointer<BinarizationOptionsWidget> otsuBinarizationOptionsWidget = new OtsuBinarizationOptionsWidget(m_settings);
+  QPointer<BinarizationOptionsWidget> otsuBinarizationOptionsWidget
+      = new OtsuBinarizationOptionsWidget(m_settings);
   QPointer<BinarizationOptionsWidget> sauvolaBinarizationOptionsWidget
       = new SauvolaBinarizationOptionsWidget(m_settings);
-  QPointer<BinarizationOptionsWidget> wolfBinarizationOptionsWidget = new WolfBinarizationOptionsWidget(m_settings);
+  QPointer<BinarizationOptionsWidget> wolfBinarizationOptionsWidget
+      = new WolfBinarizationOptionsWidget(m_settings);
+  QPointer<BinarizationOptionsWidget> edgeplusBinarizationOptionsWidget
+      = new SauvolaBinarizationOptionsWidget(m_settings);
 
   while (binarizationOptions->count() != 0) {
     binarizationOptions->removeWidget(binarizationOptions->widget(0));
@@ -57,6 +62,7 @@ OptionsWidget::OptionsWidget(std::shared_ptr<Settings> settings, const PageSelec
   addBinarizationOptionsWidget(otsuBinarizationOptionsWidget);
   addBinarizationOptionsWidget(sauvolaBinarizationOptionsWidget);
   addBinarizationOptionsWidget(wolfBinarizationOptionsWidget);
+  addBinarizationOptionsWidget(edgeplusBinarizationOptionsWidget);
   updateBinarizationOptionsDisplay(binarizationOptions->currentIndex());
 
   pictureShapeSelector->addItem(tr("Off"), OFF_SHAPE);

--- a/src/core/filters/output/OutputGenerator.cpp
+++ b/src/core/filters/output/OutputGenerator.cpp
@@ -2220,6 +2220,13 @@ BinaryImage OutputGenerator::Processor::binarize(const QImage& image) const {
       binarized = binarizeWolf(image, windowsSize, lowerBound, upperBound, wolfCoef);
       break;
     }
+    case EDGEPLUS: {
+      QSize windowsSize = QSize(blackWhiteOptions.getWindowSize(), blackWhiteOptions.getWindowSize());
+      double sauvolaCoef = blackWhiteOptions.getSauvolaCoef();
+
+      binarized = binarizeEdgePlus(image, windowsSize, sauvolaCoef);
+      break;
+    }
   }
   return binarized;
 }

--- a/src/imageproc/Binarize.cpp
+++ b/src/imageproc/Binarize.cpp
@@ -258,7 +258,7 @@ BinaryImage binarizeEdgePlus(const QImage& src, const QSize windowSize, const do
     }
     grayLine += grayBpl;
   }
-  return BinaryImage(src, BinaryThreshold::otsuThreshold(gray));
+  return BinaryImage(gray, BinaryThreshold::otsuThreshold(gray));
 }  // binarizeEdgePlus
 
 BinaryImage peakThreshold(const QImage& image) {

--- a/src/imageproc/Binarize.cpp
+++ b/src/imageproc/Binarize.cpp
@@ -196,6 +196,71 @@ BinaryImage binarizeWolf(const QImage& src,
   return bwImg;
 }  // binarizeWolf
 
+BinaryImage binarizeEdgePlus(const QImage& src, const QSize windowSize, const double k) {
+  if (windowSize.isEmpty()) {
+    throw std::invalid_argument("binarizeSauvola: invalid windowSize");
+  }
+
+  if (src.isNull()) {
+    return BinaryImage();
+  }
+
+  QImage gray(toGrayscale(src));
+  const int w = gray.width();
+  const int h = gray.height();
+
+  IntegralImage<uint32_t> integralImage(w, h);
+  IntegralImage<uint64_t> integralSqimage(w, h);
+
+  uint8_t* grayLine = gray.bits();
+  const int grayBpl = gray.bytesPerLine();
+
+  for (int y = 0; y < h; ++y, grayLine += grayBpl) {
+    integralImage.beginRow();
+    integralSqimage.beginRow();
+    for (int x = 0; x < w; ++x) {
+      const uint32_t pixel = grayLine[x];
+      integralImage.push(pixel);
+      integralSqimage.push(pixel * pixel);
+    }
+  }
+
+  const int windowLowerHalf = windowSize.height() >> 1;
+  const int windowUpperHalf = windowSize.height() - windowLowerHalf;
+  const int windowLeftHalf = windowSize.width() >> 1;
+  const int windowRightHalf = windowSize.width() - windowLeftHalf;
+
+  grayLine = gray.bits();
+  for (int y = 0; y < h; ++y) {
+    const int top = std::max(0, y - windowLowerHalf);
+    const int bottom = std::min(h, y + windowUpperHalf);  // exclusive
+    for (int x = 0; x < w; ++x) {
+      const int left = std::max(0, x - windowLeftHalf);
+      const int right = std::min(w, x + windowRightHalf);  // exclusive
+      const int area = (bottom - top) * (right - left);
+      assert(area > 0);  // because windowSize > 0 and w > 0 and h > 0
+      const QRect rect(left, top, right - left, bottom - top);
+      const double windowSum = integralImage.sum(rect);
+      const double windowSqsum = integralSqimage.sum(rect);
+
+      const double rArea = 1.0 / area;
+      const double mean = windowSum * rArea;
+      const double origin = grayLine[x];
+      // edge = I / blur (shift = -0.5) {0.0 .. >1.0}, mean value = 0.5
+      const double edge = (origin + 1) / (mean + 1)  - 0.5;
+      // edgeplus = I * edge, mean value = 0.5 * mean(I)
+      const double edgeplus = origin * edge;
+      // return k * edgeplus + (1 - k) * I
+      double retval = k * edgeplus + (1.0 - k) * origin;
+      // trim value {0..255}
+      retval = (retval < 0.0) ? 0.0 : (retval < 255.0) ? retval : 255.0;
+      grayLine[x] = (int)retval;
+    }
+    grayLine += grayBpl;
+  }
+  return BinaryImage(src, BinaryThreshold::otsuThreshold(gray));
+}  // binarizeEdgePlus
+
 BinaryImage peakThreshold(const QImage& image) {
   return BinaryImage(image, BinaryThreshold::peakThreshold(image));
 }

--- a/src/imageproc/Binarize.h
+++ b/src/imageproc/Binarize.h
@@ -60,6 +60,14 @@ BinaryImage binarizeWolf(const QImage& src,
                          unsigned char upperBound = 254,
                          double k = 0.3);
 
+/**
+ * \brief Image binarization using EdgePlus local/global thresholding method.
+ *
+ * EdgePlus, zvezdochiot 2023. "Adaptive/global document image binarization".
+ */
+BinaryImage binarizeEdgePlus(const QImage& src, QSize windowSize, double k = 0.34);
+
+
 BinaryImage peakThreshold(const QImage& image);
 }  // namespace imageproc
 #endif


### PR DESCRIPTION
Hi @4lex4 .

:warning: This PR is just a recipe. I was only able to build `binarizeEdgePlus` into the general functionality. At the same time, I use the Sauvola options, which I don’t think is correct (the new threshold requires smaller area values ​​and larger coefficient values). Due to this, projects with a new threshold are safely saved. Use this PR as a recipe.

Good Luck.
